### PR TITLE
Fixes java9_or_newer turning from True to False

### DIFF
--- a/src/main/python/RemoteSwingLibrary.py
+++ b/src/main/python/RemoteSwingLibrary.py
@@ -274,6 +274,7 @@ class RemoteSwingLibrary(object):
             RemoteSwingLibrary.DEBUG = _tobool(debug)
         if RemoteSwingLibrary.PORT is None:
             RemoteSwingLibrary.PORT = self._start_port_server(int(port))
+        RemoteSwingLibrary.JAVA9_OR_NEWER = False
         if java9_or_newer == 'auto-detect':
             RemoteSwingLibrary.JAVA9_OR_NEWER = _tobool(self._java9_or_newer())
         elif _tobool(java9_or_newer):


### PR DESCRIPTION
Corrects an issue where java9_or_newer being True first prevents Reinitiating back to False. Issue found when a test suite started Java UI with newer JDK and then tried to launch an older WebStart application.